### PR TITLE
missing feeds: don't try to process

### DIFF
--- a/packages/rai/feed.ts
+++ b/packages/rai/feed.ts
@@ -43,6 +43,9 @@ async function feedToRss(c: RssConvertConf, relUrl: string): Promise<string> {
 	});
 	const url = new URL(relUrl, c.raiBaseUrl);
 	const resp = await c.fetch(url);
+	if (!resp.ok) {
+		throw new Error(`failed to fetch feed: ${resp.status} ${resp.statusText}`);
+	}
 	const json = await resp.json();
 	return convertor.convert(json);
 }


### PR DESCRIPTION
Missing feeds were proceeding to json processing. Now we error out right away.