### PR TITLE
Add AGENTS instructions for CI tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENT Instructions
+
+To replicate the checks run by GitHub Actions, install dependencies and run the CI task just like the workflow:
+
+```bash
+npm ci
+just ci
+```
+
+Run these commands from the repository root before committing.
+


### PR DESCRIPTION
## Summary
- add AGENTS instructions describing how to run the same checks as GitHub Actions

## Testing
- `npm ci`
- `just ci` *(fails: Could not find '**/*.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_6849411adbb48327819c17944df55eec