### PR TITLE
Update worker types generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -289,7 +289,9 @@
 			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250610.0.tgz",
 			"integrity": "sha512-HxnUoey3QxCEfy07pUm7J42jBi9YPHq/hA3fw6JmOqYLHdviHI28OA8lup+2RUaHwDzh6q1DSfrBvvDqde645A==",
 			"dev": true,
-			"license": "MIT OR Apache-2.0"
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -3932,7 +3934,6 @@
 		},
 		"node_modules/npm/node_modules/lodash._baseindexof": {
 			"version": "3.1.0",
-			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
@@ -3947,19 +3948,16 @@
 		},
 		"node_modules/npm/node_modules/lodash._bindcallback": {
 			"version": "3.0.1",
-			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/lodash._cacheindexof": {
 			"version": "3.0.2",
-			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/lodash._createcache": {
 			"version": "3.1.2",
-			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3973,7 +3971,6 @@
 		},
 		"node_modules/npm/node_modules/lodash._getnative": {
 			"version": "3.9.1",
-			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
@@ -3989,7 +3986,6 @@
 		},
 		"node_modules/npm/node_modules/lodash.restparam": {
 			"version": "3.6.1",
-			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
@@ -6340,7 +6336,6 @@
 				"@raiplayrss/server": "*"
 			},
 			"devDependencies": {
-				"@cloudflare/workers-types": "^4.20250610.0",
 				"@podverse/podcast-feed-parser": "^1.1.1",
 				"@raiplayrss/rai": "*",
 				"@types/node": "^24.0.1",

--- a/packages/cf/.gitignore
+++ b/packages/cf/.gitignore
@@ -1,2 +1,4 @@
 .wrangler/
 dist/
+
+worker-configuration.d.ts

--- a/packages/cf/package.json
+++ b/packages/cf/package.json
@@ -9,12 +9,12 @@
 		"test": "node --test *.test.ts",
 		"test-only": "node --test --test-only *.test.ts",
 		"typecheck": "npm run typecheck-prod && npm run typecheck-test",
+		"pretypecheck": "wrangler types",
 		"typecheck-prod": "tsc",
 		"typecheck-test": "tsc --project tsconfig.test.json"
 	},
 	"type": "module",
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20250610.0",
 		"@podverse/podcast-feed-parser": "^1.1.1",
 		"@raiplayrss/rai": "*",
 		"@types/node": "^24.0.1",

--- a/packages/cf/tsconfig.json
+++ b/packages/cf/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"extends": "@raiplayrss/server/tsconfig.json",
-	"compilerOptions": {
-		"types": ["@cloudflare/workers-types"]
-	},
-	"include": ["*.ts"],
+	"compilerOptions": {},
+	"include": ["*.ts", "worker-configuration.d.ts"],
 	"exclude": ["*.test.ts"]
 }

--- a/packages/cf/tsconfig.test.json
+++ b/packages/cf/tsconfig.test.json
@@ -4,6 +4,6 @@
 	"compilerOptions": {
 		"types": ["node"]
 	},
-	"include": ["*.test.ts", "test/*.ts"],
+	"include": ["*.test.ts", "test/*.ts", "worker-configuration.d.ts"],
 	"exclude": []
 }


### PR DESCRIPTION
## Summary
- switch from `@cloudflare/workers-types` to `wrangler types`
- ignore generated `worker-configuration.d.ts`
- update typecheck to generate types automatically

## Testing
- `npm ci`
- `just lint`
- `just typecheck`
- `just test` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*

------
https://chatgpt.com/codex/tasks/task_e_684dd2555af0832799780c16a29724d1