### PR TITLE
Fix Biome warnings

### DIFF
--- a/packages/cf/worker.test.ts
+++ b/packages/cf/worker.test.ts
@@ -239,6 +239,6 @@ class TestServer {
 function parseFeed(feed: string): object {
 	const parsedFeed = JSON.parse(JSON.stringify(getPodcastFromFeed(feed)));
 	const { meta, ...rest } = parsedFeed;
-	const { lastBuildDate, ...metaRest } = meta;
+	const { lastBuildDate: _lastBuildDate, ...metaRest } = meta;
 	return { meta: metaRest, ...rest };
 }

--- a/packages/rai/feed.test.ts
+++ b/packages/rai/feed.test.ts
@@ -56,7 +56,7 @@ async function convertFeedNoDescriptionSuccess() {
 		block: {
 			...feedJson.block,
 			cards: feedJson.block.cards.map((card) => {
-				const { description, ...copy } = card;
+				const { description: _description, ...copy } = card;
 				return copy;
 			}),
 		},

--- a/packages/rai/test/parse-feed.ts
+++ b/packages/rai/test/parse-feed.ts
@@ -3,6 +3,6 @@ import { getPodcastFromFeed } from "@podverse/podcast-feed-parser";
 export function parseFeed(feed: string): object {
 	const parsedFeed = JSON.parse(JSON.stringify(getPodcastFromFeed(feed)));
 	const { meta, ...rest } = parsedFeed;
-	const { lastBuildDate, ...metaRest } = meta;
+	const { lastBuildDate: _lastBuildDate, ...metaRest } = meta;
 	return { meta: metaRest, ...rest };
 }


### PR DESCRIPTION
## Summary
- cleanup unused variables causing Biome warnings

## Testing
- `just lint`
- `just test` *(fails: ERR_TEST_FAILURE)*
- `just typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68527481eb808327a893abf730c89f71